### PR TITLE
metakeys protocol for launchpad and handler

### DIFF
--- a/src/overtone/grid/launchpad.clj
+++ b/src/overtone/grid/launchpad.clj
@@ -98,7 +98,6 @@
    :arm [:note-on 120]})
 
 (def midi->metakeys
-  ;reverse the map
   (map-invert metakeys->midi))
 
 (defn get-metakey

--- a/src/overtone/grid/launchpad.clj
+++ b/src/overtone/grid/launchpad.clj
@@ -1,6 +1,7 @@
 (ns overtone.grid.launchpad
   (:use [overtone grid midi]
         [clojure.set :only [map-invert]])
+  (:require [clojure.stacktrace])
   (:import (javax.sound.midi ShortMessage)))
 
 ;;; Launchpad implementation of a Grid controller.
@@ -78,9 +79,8 @@
 (defn both-buffers [colour]
   (bit-or colour 4r030))
 
-(def metakeys->midinote
-  (array-map
-   :up [:control-change 104] 
+(def metakeys->midi
+  {:up [:control-change 104] 
    :down [:control-change 105]
    :left [:control-change 106] 
    :right [:control-change 107] 
@@ -95,56 +95,59 @@
    :stop [:note-on 72]
    :trkon [:note-on 88]
    :solo [:note-on 104]
-   :arm [:note-on 120]))
+   :arm [:note-on 120]})
 
-(def midinote->metakeys
+(def midi->metakeys
   ;reverse the map
-  (into (array-map) (for [[k v] metakeys->midinote] [v k])))
+  (map-invert metakeys->midi))
 
 (defn get-metakey
   "returns the metakey, or nil if it's not a metakey"
   [event]
-  (midinote->metakeys [(midi-shortmessage-command (:cmd event)) (:note event)]))
+  (midi->metakeys [(midi-shortmessage-command (:cmd event)) (:note event)]))
 
 (defn midi-handler [launchpad f]
   (fn [event ts]
-    (if-let [metakey (get-metakey event)]
-      (let [action @(.bindings-fn-atom launchpad)]
-        (if (zero? (:vel event))
-          (action :release metakey)
-          (action :press metakey)))
-      (when (= (:cmd event) (cmd->java-cmd :note-on))
-        (if (contains? midi-note->coords (:note event))
-          (let [note  (:note event)
-                [x y] (midi-note->coords note)]
-            (if (zero? (:vel event))
-              (f :release x y)
-              (f :press   x y))))))))
+    (try 
+      (if-let [metakey (get-metakey event)]
+        (let [action (:metakey-fn launchpad)]
+          (if (zero? (:vel event))
+            (action :release metakey)
+            (action :press metakey)))
+        (when (= (:cmd event) (cmd->java-cmd :note-on))
+          (if (contains? midi-note->coords (:note event))
+            (let [note  (:note event)
+                  [x y] (midi-note->coords note)]
+              (if (zero? (:vel event))
+                (f :release x y)
+                (f :press   x y))))))
+      (catch Exception e ;Don't let the midi thread die, it's messy
+        (clojure.stacktrace/print-stack-trace e)))))
 
 (defprotocol MetaKeys
   "A representation binding functionality to meta-keys, assuming they won't be part of the standard
    grid interface, an implementation will report its functionality and let you bind handlers to the metakeys"
   (meta-led-set [this key colour] "If supported, set the color of an led on the key")
-  (meta-bind [this binding-fn] "Binds a functions to keypresses"))
+  (meta-list-keys [this] "lists all the supported keys, informational"))
 
-(defn launchpad-set-meta-led [midi-out key color]
-  (let [[cmd note] (metakeys->midinote key)
-        msg (make-ShortMessage cmd note (both-buffers (colours color)))]
+(defn launchpad-set-meta-led [midi-out key palette color]
+  (let [[cmd note] (metakeys->midi key)
+        msg (make-ShortMessage cmd note (both-buffers (colours (palette color))))]
     (midi-send midi-out msg)))
 
 
-(defrecord Launchpad [launchpad-in launchpad-out palette bindings-fn-atom]
+(defrecord Launchpad [launchpad-in launchpad-out palette metakey-fn]
   MetaKeys
   (meta-led-set [this key colour]
-    (launchpad-set-meta-led launchpad-out key colour))
-  (meta-bind [this binding-fn] (swap! bindings-fn-atom (constantly binding-fn)))
+    (launchpad-set-meta-led launchpad-out key palette colour))
+  (meta-list-keys [this] (keys metakeys->midi))
   Grid
   (on-action [this f group name]   ; currently ignoring group and name
-    (midi-handle-events launchpad-in (#'midi-handler this f)))
+    (midi-handle-events launchpad-in (midi-handler this f)))
   (set-all-leds [this colour]
     (led-frame this (repeat 8 (repeat 8 colour))))
   (led-set [this x y colour]
-    (midi-note-on launchpad-out (coords->midi-note x y) (both-buffers (colours colour))))
+    (midi-note-on launchpad-out (coords->midi-note x y) (both-buffers (colours (palette colour)))))
   (led-frame [this leds]
     (midi-send launchpad-out display-buffer-0)
     (let [coords (for [y (range 8)
@@ -163,11 +166,11 @@
   [:off :red :green :yellow])
 
 (defn make-launchpad
-  "Creates an 8x8 Grid implementation backed by a launchpad."
-  ([] (make-launchpad default-palette))
-  ([palette]
+  "Creates an 8x8 Grid implementation backed by a launchpad. Metakey-fn must be a function of 2 args [type metakey], where the midi thread will call it and pass in :press or :release and the keyword associated to the metakey"
+  ([metakey-fn] (make-launchpad metakey-fn default-palette))
+  ([metakey-fn palette]
      (if-let [launchpad-in (midi-in "Launchpad")]
        (if-let [launchpad-out (midi-out "Launchpad")]
-         (Launchpad. launchpad-in launchpad-out palette (atom {}))
+         (Launchpad. launchpad-in launchpad-out palette metakey-fn)
          (throw (Exception. "Found launchpad for input but couldn't find it for output")))
        (throw (Exception. "Couldn't find launchpad")))))

--- a/src/overtone/grid/launchpad.clj
+++ b/src/overtone/grid/launchpad.clj
@@ -80,6 +80,7 @@
 
 (defn midi-handler [f]
   (fn [event ts]
+    (println event)
     (when (= (:cmd event) (cmd->java-cmd :note-on))
       (when (contains? midi-note->coords (:note event))
         (let [note  (:note event)
@@ -88,14 +89,63 @@
             (f :release x y)
             (f :press   x y)))))))
 
-(defrecord Launchpad [launchpad-in launchpad-out palette]
+(defprotocol MetaKeys
+  "A representation binding functionality to meta-keys, assuming they won't be part of the standard
+   grid interface, an implementation will report its functionality and let you bind handlers to the metakeys"
+  (get-metakeys [this] "Return a map of keys to supported functions, just informational")
+  (meta-led-set [this key colour] "If supported, set the color of an led on the key")
+  (meta-bind [this key bindings] "Binds a map of functions to keypresses")
+  (meta-get-bindings [this] "Returns the bindings"))
+
+(def metakeys->midinote
+  (array-map
+   :up 104 
+   :down 105
+   :left 106 
+   :right 107 
+   :session 108
+   :user1 109
+   :user2 110
+   :mixer 111
+   :vol 8
+   :pan 24
+   :snda 40
+   :sndb 56
+   :stop 72
+   :trkon 88
+   :solo 104
+   :arm 120))
+
+(def midinote->metakeys
+  ;reverse the map
+  (into (array-map) (for [[k v] metakeys->midinote] [v k])))
+
+
+
+(defn launchpad-set-meta-led [midi-out key color]
+  (let [note (metakeys->midinote key 104)
+        msg (make-ShortMessage (if (>= note 104)
+                                 :control-change
+                                 :note-on)
+                               note (both-buffers (colours color)))]
+    (midi-send midi-out msg)))
+
+
+(defrecord Launchpad [launchpad-in launchpad-out palette bindings-atom]
+  MetaKeys
+  (get-metakeys [this] (apply array-map (interleave (keys metakeys->midinote) (cycle [[:led-set :bind]]))))
+  (meta-led-set [this key colour]
+    (launchpad-set-meta-led launchpad-out key colour))
+  (meta-bind [this key bindings] (swap! bindings-atom (constantly bindings)))
+  (meta-get-bindings [this] @bindings-atom)
   Grid
   (on-action [this f group name]   ; currently ignoring group and name
-    (midi-handle-events launchpad-in (midi-handler f)))
+    (midi-handle-events launchpad-in (#'midi-handler f)))
   (set-all-leds [this colour]
     (led-frame this (repeat 8 (repeat 8 colour))))
   (led-set [this x y colour]
-    (midi-note-on launchpad-out (coords->midi-note x y) (both-buffers (colours (palette colour)))))
+    (midi-note-on launchpad-out (coords->midi-note x y) (both-buffers (colours colour;(palette colour)
+                                                                               ))))
   (led-frame [this leds]
     (midi-send launchpad-out display-buffer-0)
     (let [coords (for [y (range 8)
@@ -105,7 +155,7 @@
         (let [colour-1 (colours (palette (get leds coord-1 0)))
               colour-2 (colours (palette (get leds coord-2 0)))]
           (midi-send launchpad-out (make-ShortMessage 2 :note-on colour-1 colour-2)))))
-    (midi-send launchpad-out display-buffer-1)) )
+    (midi-send launchpad-out display-buffer-1))) 
 
 (defmethod print-method Launchpad [lp w]
   (.write w (format "#<Launchpad palette%s>" (:palette lp))))
@@ -119,6 +169,6 @@
   ([palette]
      (if-let [launchpad-in (midi-in "Launchpad")]
        (if-let [launchpad-out (midi-out "Launchpad")]
-         (Launchpad. launchpad-in launchpad-out palette)
+         (Launchpad. launchpad-in launchpad-out palette (atom {}))
          (throw (Exception. "Found launchpad for input but couldn't find it for output")))
        (throw (Exception. "Couldn't find launchpad")))))


### PR DESCRIPTION
Questions for review: wouldn't it make sense to use an atom for on-action instead of binding the midi-handler there? do the midi-handler stuff on record construction.  How's it look?
